### PR TITLE
avoid calling head on empty list

### DIFF
--- a/src/Faker/Internet.hs
+++ b/src/Faker/Internet.hs
@@ -55,11 +55,14 @@ userName = do
     lName <- N.lastName
     let loweredFName = loweredLetters fName
         loweredLName = loweredLetters lName
-    ind <- randomInt (0,2)
-    return $ case ind of
-               0 -> loweredFName ++ "." ++ loweredLName
-               1 -> head loweredFName : '.' :loweredLName
-               _ -> head loweredFName : loweredLName
+    if null loweredFName
+      then userName
+      else do
+        ind <- randomInt (0,2)
+        return $ case ind of
+                0 -> loweredFName ++ "." ++ loweredLName
+                1 -> head loweredFName : '.' :loweredLName
+                _ -> head loweredFName : loweredLName
 
 loweredLetters :: String -> String
 loweredLetters str = map toLower $ filter isLetter str


### PR DESCRIPTION
*The following description is based on faker-0.0.0.2. Version 0.0.0.3 on github doesn't work for me:* `*** Exception: ../data/en.giml: openFile: does not exist (No such file or directory)`.

The following is the relevant part of the current implementation of `Faker.Internet.safeEmail`:

```haskell
-- | Returns random username, i.e. "k.johnson"
userName :: Faker String
userName = do
    fName <- N.firstName
    lName <- N.lastName
    let loweredFName = loweredLetters fName
        loweredLName = loweredLetters lName
    ind <- randomInt (0,2)
    return $ case ind of
               0 -> loweredFName ++ "." ++ loweredLName
               1 -> head loweredFName : '.' :loweredLName
               _ -> head loweredFName : loweredLName

loweredLetters :: String -> String
loweredLetters str = map toLower $ filter isLetter str
```

If `ind > 0` and `loweredLetters fName == ""` then `error` is triggered in the implementation 
of `Prelude.head`. The following ghci session demonstrates that this can happen with faker-0.0.0.2 and gimlh-0.1.2.0.

```haskell
λ import Data.Char
λ import Faker.Name -- version 0.0.0.2
λ import Control.Monad
λ let loweredLetters str = map toLower $ filter isLetter str
λ replicateM_ 10000 $ firstName >>= \x -> when (null $ loweredLetters x) (error "empty first name")
*** Exception: empty first name
```

Here is another GHCI session that uses `safeEmail` directly, but takes longer to trigger the issue:

```haskell
λ import Control.DeepSeq 
λ import Control.Monad
λ import Faker.Internet -- version 0.0.0.2
λ replicateM_ 50000 $ safeEmail >>= \x -> x `deepseq` return ()
*** Exception: Prelude.head: empty list
```

The proposed fix simply retries calling `userName` until `loweredFName` is not null. In practice at most a single retry should be needed and even that case is rare.